### PR TITLE
Add FunctionTool decorators directly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+__pycache__/
+workout.db
+.env
+sample_workout.db
+
+node_modules/
+package-lock.json
+package.json

--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# CoachByte Agent Demo
+
+This demo shows a simple agent built with the OpenAI Agents SDK connected to a SQLite database for tracking workouts. Tools mirror the planned production API.
+
+## Setup
+1. Install requirements:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Set an `OPENAI_API_KEY` environment variable for the agent.
+
+## Running Tests
+There are two test scripts. Each one sends natural language prompts so the agent chooses the right tools:
+
+```bash
+python test_tools.py       # exercises all dedicated tools
+python test_arbitrary.py   # demonstrates the arbitrary_update escape hatch
+```
+
+Run `demo_chat.py` to interact with the agent in a simple console chat powered by the OpenAI Agents SDK.

--- a/agent.py
+++ b/agent.py
@@ -1,0 +1,31 @@
+import os
+from typing import List
+
+from agents import Agent
+
+import tools
+
+# Use environment variable OPENAI_API_KEY by default
+
+MODEL = os.environ.get("OPENAI_MODEL", "gpt-4o")
+
+def create_agent() -> Agent:
+    """Return a CoachByte agent configured with available tools."""
+    return Agent(
+        name="CoachByte",
+        instructions=(
+            "You manage workout plans and logs. Use tools whenever they can help"
+        ),
+        tools=[
+            tools.get_today_plan,
+            tools.log_completed_set,
+            tools.new_daily_plan,
+            tools.update_summary,
+            tools.get_recent_history,
+            tools.run_sql,
+            tools.arbitrary_update,
+        ],
+        model=MODEL,
+    )
+
+

--- a/db.py
+++ b/db.py
@@ -1,0 +1,113 @@
+import os
+import sqlite3
+import uuid
+from datetime import datetime, date
+
+DB_PATH = os.environ.get("WORKOUT_DB", "workout.db")
+
+# Connection helper
+def get_connection():
+    conn = sqlite3.connect(DB_PATH, detect_types=sqlite3.PARSE_DECLTYPES | sqlite3.PARSE_COLNAMES)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+# Initialize database with schema
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS exercises (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT UNIQUE NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS daily_logs (
+    id TEXT PRIMARY KEY,
+    log_date DATE NOT NULL UNIQUE,
+    summary TEXT
+);
+
+CREATE TABLE IF NOT EXISTS planned_sets (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    log_id TEXT REFERENCES daily_logs(id) ON DELETE CASCADE,
+    exercise_id INTEGER REFERENCES exercises(id),
+    order_num INTEGER NOT NULL,
+    reps INTEGER NOT NULL,
+    load REAL NOT NULL
+);
+CREATE INDEX IF NOT EXISTS ix_planned_order ON planned_sets (log_id, order_num);
+
+CREATE TABLE IF NOT EXISTS completed_sets (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    log_id TEXT REFERENCES daily_logs(id) ON DELETE CASCADE,
+    exercise_id INTEGER REFERENCES exercises(id),
+    reps_done INTEGER,
+    load_done REAL,
+    completed_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX IF NOT EXISTS ix_completed_time ON completed_sets (log_id, completed_at);
+"""
+
+
+def init_db(sample: bool = False):
+    """Create a new database. If sample=True, populate with demo data."""
+    if os.path.exists(DB_PATH):
+        os.remove(DB_PATH)
+    conn = get_connection()
+    conn.executescript(SCHEMA)
+    if sample:
+        populate_sample_data(conn)
+    conn.commit()
+    conn.close()
+
+
+def populate_sample_data(conn: sqlite3.Connection):
+    today = date.today().isoformat()
+    log_id = str(uuid.uuid4())
+    conn.execute("INSERT INTO daily_logs (id, log_date, summary) VALUES (?, ?, '')", (log_id, today))
+
+    def add_ex(name):
+        cur = conn.execute("INSERT INTO exercises (name) VALUES (?) RETURNING id", (name,))
+        return cur.fetchone()[0]
+
+    bench = add_ex("bench press")
+    squat = add_ex("squat")
+    deadlift = add_ex("deadlift")
+
+    planned = [
+        (bench, 1, 10, 45),
+        (bench, 2, 8, 65),
+        (bench, 3, 5, 85),
+        (squat, 4, 10, 95),
+        (squat, 5, 8, 135),
+        (squat, 6, 5, 185),
+        (deadlift, 7, 5, 135),
+        (deadlift, 8, 5, 185),
+        (deadlift, 9, 3, 225),
+    ]
+    for ex_id, order_num, reps, load in planned:
+        conn.execute(
+            "INSERT INTO planned_sets (log_id, exercise_id, order_num, reps, load) VALUES (?, ?, ?, ?, ?)",
+            (log_id, ex_id, order_num, reps, load),
+        )
+
+    completed = [
+        (bench, 1, 10, 45),
+        (bench, 2, 8, 65),
+        (squat, 4, 10, 95),
+        (deadlift, 7, 5, 135),
+    ]
+    for ex_id, order_num, reps, load in completed:
+        conn.execute(
+            "INSERT INTO completed_sets (log_id, exercise_id, reps_done, load_done, completed_at) VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP)",
+            (log_id, ex_id, reps, load),
+        )
+
+
+def get_today_log_id(conn):
+    today = date.today().isoformat()
+    cur = conn.execute("SELECT id FROM daily_logs WHERE log_date = ?", (today,))
+    row = cur.fetchone()
+    if row:
+        return row[0]
+    log_id = str(uuid.uuid4())
+    conn.execute("INSERT INTO daily_logs (id, log_date) VALUES (?, ?)", (log_id, today))
+    conn.commit()
+    return log_id

--- a/demo_chat.py
+++ b/demo_chat.py
@@ -1,0 +1,20 @@
+import db
+from agent import create_agent
+from agents import Runner
+
+
+def main():
+    db.init_db(sample=True)
+    agent = create_agent()
+    print("CoachByte demo. Type 'quit' to exit.")
+    while True:
+        user_input = input("You: ")
+        if user_input.strip().lower() in {"quit", "exit"}:
+            break
+        result = Runner.run_sync(agent, user_input)
+        print(result.final_output)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/models.py
+++ b/models.py
@@ -1,0 +1,28 @@
+from typing import List, Dict, Optional
+from pydantic import BaseModel, Field, conint, confloat, ConfigDict
+
+MAX_LOAD = 2000
+MAX_REPS = 100
+
+class PlanItem(BaseModel):
+    exercise: str
+    order: conint(ge=1)
+    reps: conint(ge=1, le=MAX_REPS)
+    load: confloat(ge=0, le=MAX_LOAD)
+
+    model_config = ConfigDict(extra="forbid")
+
+class LogCompletedInput(BaseModel):
+    exercise: str
+    reps: conint(ge=1, le=MAX_REPS)
+    load: confloat(ge=0, le=MAX_LOAD)
+
+    model_config = ConfigDict(extra="forbid")
+
+class RunSQLInput(BaseModel):
+    query: str
+    params: Optional[Dict] = None
+    confirm: bool = False
+
+    model_config = ConfigDict(extra="forbid")
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ uvicorn[standard]
 python-dotenv
 langchain
 langchain-openai
+openai-agents
 psycopg2-binary
 pydantic>=2.0.0
 streamlit

--- a/test_arbitrary.py
+++ b/test_arbitrary.py
@@ -1,0 +1,48 @@
+import db
+import sqlite3
+from db import get_connection
+import tools
+from agent import create_agent
+from agents import Runner
+
+def reset_db():
+    db.init_db(sample=True)
+
+
+def query(sql: str, params: tuple | None = None):
+    conn = get_connection()
+    try:
+        cur = conn.execute(sql, params or ())
+        return [dict(row) for row in cur.fetchall()]
+    finally:
+        conn.close()
+
+
+def run_tests():
+    reset_db()
+    agent = create_agent()
+
+    tables = ["exercises", "daily_logs", "planned_sets", "completed_sets"]
+    for table in tables:
+        print(f"-- Initial {table} --")
+        print(query(f"SELECT * FROM {table}"))
+
+    print("-- Add exercise via arbitrary_update --")
+    print("Before:", query("SELECT * FROM exercises"))
+    Runner.run_sync(agent, "Add an exercise called pull up. Use the arbitrary update tool with {\"query\": \"INSERT INTO exercises(name) VALUES (:n)\", \"params\": {\"n\": \"pull up\"}}")
+    print("After:", query("SELECT * FROM exercises"))
+
+    print("-- Update load in planned_sets --")
+    print("Before:", query("SELECT id, load FROM planned_sets WHERE id=1"))
+    Runner.run_sync(agent, "Increase the load of the first planned set by five. Use the arbitrary update tool with {\"query\": \"UPDATE planned_sets SET load = load + 5 WHERE id = 1\", \"params\": {}}")
+    print("After:", query("SELECT id, load FROM planned_sets WHERE id=1"))
+
+    print("-- Insert completed_set --")
+    print("Before:", query("SELECT * FROM completed_sets"))
+    Runner.run_sync(agent, "Insert a completed set of 5 reps at 45 pounds for the first exercise. Use the arbitrary update tool exactly with this JSON: {\"query\": \"INSERT INTO completed_sets(log_id, exercise_id, reps_done, load_done) VALUES ((SELECT id FROM daily_logs LIMIT 1), (SELECT id FROM exercises LIMIT 1), 5, 45)\", \"params\": {}}")
+    print("After:", query("SELECT * FROM completed_sets"))
+
+
+if __name__ == "__main__":
+    run_tests()
+

--- a/test_tools.py
+++ b/test_tools.py
@@ -1,0 +1,54 @@
+import db
+import sqlite3
+from db import get_connection
+import tools
+from agent import create_agent
+from agents import Runner
+
+
+def reset_db():
+    db.init_db()
+
+
+def query(sql: str, params: tuple | None = None):
+    conn = get_connection()
+    try:
+        cur = conn.execute(sql, params or ())
+        return [dict(row) for row in cur.fetchall()]
+    finally:
+        conn.close()
+
+
+def run_tests():
+    reset_db()
+    agent = create_agent()
+
+    print("-- Create today's plan --")
+    print("Before:", query("SELECT * FROM planned_sets"))
+    plan = [
+        {"exercise": "bench press", "order": 1, "reps": 10, "load": 100},
+        {"exercise": "squat", "order": 2, "reps": 8, "load": 150},
+    ]
+    res = Runner.run_sync(agent, "Please set up today's workout with bench press for 10 reps at 100 pounds as set 1 and squat for 8 reps at 150 pounds as set 2.")
+    print(res.final_output)
+    print("After:", query("SELECT * FROM planned_sets"))
+
+    print("-- Log completed set --")
+    print("Before:", query("SELECT * FROM completed_sets"))
+    res = Runner.run_sync(agent, "I just finished a bench press set of 10 reps at 100 pounds.")
+    print(res.final_output)
+    print("After:", query("SELECT * FROM completed_sets"))
+
+    print("-- Update summary --")
+    print("Before:", query("SELECT summary FROM daily_logs"))
+    Runner.run_sync(agent, "Please record the summary 'Great session' for today.")
+    print("After:", query("SELECT summary FROM daily_logs"))
+
+    print("-- Get recent history --")
+    res = Runner.run_sync(agent, "Show me the workout history for the last day.")
+    print(res.final_output)
+
+
+if __name__ == "__main__":
+    run_tests()
+

--- a/tools.py
+++ b/tools.py
@@ -1,0 +1,154 @@
+from typing import List, Dict, Any
+from datetime import date, timedelta
+import sqlite3
+
+from db import get_connection, get_today_log_id
+from agents import function_tool
+
+# Helper validation
+MAX_LOAD = 2000
+MAX_REPS = 100
+
+
+def _get_exercise_id(conn: sqlite3.Connection, name: str) -> int:
+    cur = conn.execute("SELECT id FROM exercises WHERE name = ?", (name,))
+    row = cur.fetchone()
+    if row:
+        return row[0]
+    cur = conn.execute("INSERT INTO exercises (name) VALUES (?)", (name,))
+    return cur.lastrowid
+
+
+@function_tool(strict_mode=False)
+def new_daily_plan(items: List[Dict[str, Any]]):
+    """Create today's daily log and planned sets"""
+    conn = get_connection()
+    try:
+        log_id = get_today_log_id(conn)
+        for item in items:
+            reps = int(item["reps"])
+            load = float(item["load"])
+            if not (1 <= reps <= MAX_REPS):
+                raise ValueError("reps out of range")
+            if not (0 <= load <= MAX_LOAD):
+                raise ValueError("load out of range")
+            exercise_id = _get_exercise_id(conn, item["exercise"])
+            order_num = int(item["order"])
+            conn.execute(
+                "INSERT INTO planned_sets (log_id, exercise_id, order_num, reps, load) VALUES (?, ?, ?, ?, ?)",
+                (log_id, exercise_id, order_num, reps, load),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+    return f"planned {len(items)} sets for today"
+
+
+@function_tool(strict_mode=False)
+def get_today_plan() -> List[Dict[str, Any]]:
+    """Return today's planned sets in workout order."""
+    conn = get_connection()
+    try:
+        log_id = get_today_log_id(conn)
+        cur = conn.execute(
+            "SELECT e.name as exercise, reps, load, order_num FROM planned_sets ps JOIN exercises e ON ps.exercise_id = e.id WHERE log_id = ? ORDER BY order_num",
+            (log_id,),
+        )
+        rows = [dict(row) for row in cur.fetchall()]
+    finally:
+        conn.close()
+    return rows
+
+
+@function_tool(strict_mode=False)
+def log_completed_set(exercise: str, reps: int, load: float):
+    """Record a completed set for today."""
+    if not (1 <= reps <= MAX_REPS):
+        raise ValueError("reps out of range")
+    if not (0 <= load <= MAX_LOAD):
+        raise ValueError("load out of range")
+    conn = get_connection()
+    try:
+        log_id = get_today_log_id(conn)
+        exercise_id = _get_exercise_id(conn, exercise)
+        conn.execute(
+            "INSERT INTO completed_sets (log_id, exercise_id, reps_done, load_done) VALUES (?, ?, ?, ?)",
+            (log_id, exercise_id, reps, load),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    return "logged"
+
+
+@function_tool(strict_mode=False)
+def update_summary(text: str):
+    """Update today's daily log summary."""
+    conn = get_connection()
+    try:
+        log_id = get_today_log_id(conn)
+        conn.execute("UPDATE daily_logs SET summary = ? WHERE id = ?", (text, log_id))
+        conn.commit()
+    finally:
+        conn.close()
+    return "summary updated"
+
+
+@function_tool(strict_mode=False)
+def get_recent_history(days: int) -> List[Dict[str, Any]]:
+    """Return planned and completed sets for the last ``days`` calendar days."""
+    conn = get_connection()
+    try:
+        start = date.today() - timedelta(days=days)
+        cur = conn.execute(
+            """
+            SELECT dl.log_date, e.name as exercise, ps.reps, ps.load, cs.reps_done, cs.load_done
+            FROM planned_sets ps
+            JOIN daily_logs dl ON ps.log_id = dl.id
+            JOIN exercises e ON ps.exercise_id = e.id
+            LEFT JOIN completed_sets cs ON cs.log_id = ps.log_id AND cs.exercise_id = ps.exercise_id
+            WHERE dl.log_date >= ?
+            ORDER BY dl.log_date, ps.order_num
+            """,
+            (start.isoformat(),),
+        )
+        rows = [dict(row) for row in cur.fetchall()]
+    finally:
+        conn.close()
+    return rows
+
+
+@function_tool(strict_mode=False)
+def run_sql(query: str, params: Dict[str, Any] = None, confirm: bool = False):
+    """Run arbitrary SQL. Reject mutations unless confirm=True"""
+    params = params or {}
+    lowered = query.strip().lower()
+    if not lowered.startswith("select") and not confirm:
+        raise ValueError("updates require confirm=True")
+    conn = get_connection()
+    try:
+        cur = conn.execute(query, params)
+        if lowered.startswith("select"):
+            rows = [dict(row) for row in cur.fetchall()]
+        else:
+            conn.commit()
+            rows = {"rows_affected": cur.rowcount}
+    finally:
+        conn.close()
+    return rows
+
+
+@function_tool(strict_mode=False)
+def arbitrary_update(query: str, params: Dict[str, Any] = None):
+    """Execute a confirmed SQL statement for updates or inserts."""
+    return run_sql(query, params=params, confirm=True)
+
+__all__ = [
+    "new_daily_plan",
+    "get_today_plan",
+    "log_completed_set",
+    "update_summary",
+    "get_recent_history",
+    "run_sql",
+    "arbitrary_update",
+]


### PR DESCRIPTION
## Summary
- expose workout database helpers directly as `FunctionTool`-decorated callables
- update agent setup to use these decorated tools
- fix tests to inspect database through sqlite3

## Testing
- `python test_tools.py`
- `python test_arbitrary.py`


------
https://chatgpt.com/codex/tasks/task_e_6865a19bf8488320a2e71823c50ef049