### PR TITLE
Add persistent chat sidebar and improved layout

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import DayDetail from './DayDetail';
+import ChatSidebar from './ChatSidebar';
 
 export default function App() {
   const [days, setDays] = useState([]);
@@ -46,10 +47,12 @@ export default function App() {
   };
 
   return (
-    <div style={{ padding: 20 }}>
-      {!selected && (
-        <div>
-          <h2>Workout Days</h2>
+    <>
+      <ChatSidebar />
+      <div id="main-container">
+        {!selected && (
+          <div>
+            <h2>Workout Days</h2>
           {loading && <p>Loading workout days...</p>}
           {!loading && days.length === 0 && (
             <div>
@@ -79,6 +82,7 @@ export default function App() {
         </div>
       )}
       {selected && <DayDetail id={selected} onBack={handleBack} />}
-    </div>
+      </div>
+    </>
   );
 }

--- a/src/ChatSidebar.jsx
+++ b/src/ChatSidebar.jsx
@@ -1,0 +1,31 @@
+import React, { useState } from 'react';
+
+export default function ChatSidebar() {
+  const [input, setInput] = useState('');
+  const [messages, setMessages] = useState([]);
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    if (!input.trim()) return;
+    setMessages([...messages, input]);
+    setInput('');
+  };
+
+  return (
+    <div className="sidebar">
+      <form className="chat-input" onSubmit={handleSubmit}>
+        <input
+          type="text"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder="Type a message..."
+        />
+      </form>
+      <div className="chat-history">
+        {messages.map((m, i) => (
+          <div key={i} className="chat-message">{m}</div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/DayDetail.jsx
+++ b/src/DayDetail.jsx
@@ -72,8 +72,9 @@ export default function DayDetail({ id, onBack }) {
     <div>
       <button onClick={onBack}>Back</button>
       <h3>{data.log.log_date}</h3>
-      <div>
-        <h4>Planned Sets</h4>
+      <div className="tables-row">
+        <div>
+          <h4>Planned Sets</h4>
         <table border="1" cellPadding="4">
           <thead><tr><th>Exercise</th><th>Reps</th><th>Load</th><th>Order</th><th></th></tr></thead>
           <tbody>
@@ -95,10 +96,10 @@ export default function DayDetail({ id, onBack }) {
             </tr>
           </tbody>
         </table>
-      </div>
-      <div>
-        <h4>Completed Sets</h4>
-        <table border="1" cellPadding="4">
+        </div>
+        <div>
+          <h4>Completed Sets</h4>
+          <table border="1" cellPadding="4">
           <thead><tr><th>Exercise</th><th>Reps</th><th>Load</th><th></th></tr></thead>
           <tbody>
             {data.completed.map((c,i) => (
@@ -117,6 +118,7 @@ export default function DayDetail({ id, onBack }) {
             </tr>
           </tbody>
         </table>
+        </div>
       </div>
       <div>
         <h4>Summary</h4>

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
+import './styles.css';
 
 ReactDOM.createRoot(document.getElementById('root')).render(<App />);

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,0 +1,61 @@
+body {
+  margin: 0;
+  font-family: Arial, sans-serif;
+}
+
+.sidebar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  width: 30%;
+  max-width: 350px;
+  background: #f5f5f5;
+  border-right: 1px solid #ddd;
+  display: flex;
+  flex-direction: column;
+}
+
+.chat-input {
+  padding: 10px;
+  border-bottom: 1px solid #ddd;
+}
+
+.chat-input input {
+  width: 100%;
+  padding: 8px;
+}
+
+.chat-history {
+  flex: 1;
+  overflow-y: auto;
+  padding: 10px;
+}
+
+#main-container {
+  margin-left: 30%;
+  padding: 20px;
+  box-sizing: border-box;
+}
+
+.tables-row {
+  display: flex;
+  gap: 20px;
+  align-items: flex-start;
+}
+
+.tables-row > div {
+  flex: 1;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 20px;
+}
+
+table th,
+table td {
+  border: 1px solid #ccc;
+  padding: 4px;
+}


### PR DESCRIPTION
## Summary
- add sidebar with simple chat functionality
- keep sidebar fixed on the left and shift main content right
- show planned and completed sets next to each other
- import global styles for a cleaner appearance

## Testing
- `pytest -q` *(fails: connection to PostgreSQL blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686a3ccf97c48320bcf9fb908eff49e7