### PR TITLE
Add chat sidebar and improve day layout

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import DayDetail from './DayDetail';
+import Sidebar from './Sidebar';
 
 export default function App() {
   const [days, setDays] = useState([]);
@@ -47,6 +48,7 @@ export default function App() {
 
   return (
     <div style={{ padding: 20 }}>
+      <Sidebar />
       {!selected && (
         <div>
           <h2>Workout Days</h2>

--- a/src/DayDetail.jsx
+++ b/src/DayDetail.jsx
@@ -72,8 +72,9 @@ export default function DayDetail({ id, onBack }) {
     <div>
       <button onClick={onBack}>Back</button>
       <h3>{data.log.log_date}</h3>
-      <div>
-        <h4>Planned Sets</h4>
+      <div className="sets-container">
+        <div className="plan-section">
+          <h4>Planned Sets</h4>
         <table border="1" cellPadding="4">
           <thead><tr><th>Exercise</th><th>Reps</th><th>Load</th><th>Order</th><th></th></tr></thead>
           <tbody>
@@ -95,9 +96,9 @@ export default function DayDetail({ id, onBack }) {
             </tr>
           </tbody>
         </table>
-      </div>
-      <div>
-        <h4>Completed Sets</h4>
+        </div>
+        <div className="completed-section">
+          <h4>Completed Sets</h4>
         <table border="1" cellPadding="4">
           <thead><tr><th>Exercise</th><th>Reps</th><th>Load</th><th></th></tr></thead>
           <tbody>
@@ -117,6 +118,7 @@ export default function DayDetail({ id, onBack }) {
             </tr>
           </tbody>
         </table>
+        </div>
       </div>
       <div>
         <h4>Summary</h4>

--- a/src/Sidebar.jsx
+++ b/src/Sidebar.jsx
@@ -1,0 +1,39 @@
+import React, { useState } from 'react';
+import './styles.css';
+
+export default function Sidebar() {
+  const [open, setOpen] = useState(false);
+  const [input, setInput] = useState('');
+  const [messages, setMessages] = useState([]);
+
+  const sendMessage = (e) => {
+    e.preventDefault();
+    if (!input.trim()) return;
+    setMessages([...messages, input]);
+    setInput('');
+  };
+
+  return (
+    <>
+      <button className="sidebar-toggle" onClick={() => setOpen(!open)}>
+        {open ? 'Close' : 'Chat'}
+      </button>
+      <div className={`sidebar ${open ? 'open' : ''}`}>
+        <form onSubmit={sendMessage}>
+          <input
+            className="chat-input"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            placeholder="Type a message"
+          />
+        </form>
+        <div className="chat-history">
+          {messages.map((m, i) => (
+            <div key={i} className="chat-message">{m}</div>
+          ))}
+        </div>
+      </div>
+    </>
+  );
+}
+

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
+import './styles.css';
 
 ReactDOM.createRoot(document.getElementById('root')).render(<App />);

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,0 +1,64 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+}
+
+.sidebar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 30%;
+  max-width: 350px;
+  background: #f5f5f5;
+  box-shadow: 2px 0 5px rgba(0,0,0,0.1);
+  transform: translateX(-100%);
+  transition: transform 0.3s ease;
+  display: flex;
+  flex-direction: column;
+  z-index: 1000;
+}
+.sidebar.open {
+  transform: translateX(0);
+}
+.sidebar-toggle {
+  position: fixed;
+  top: 10px;
+  left: 10px;
+  z-index: 1100;
+}
+.chat-input {
+  border: none;
+  border-bottom: 1px solid #ccc;
+  padding: 8px;
+  width: calc(100% - 16px);
+  box-sizing: border-box;
+}
+.chat-history {
+  flex: 1;
+  overflow-y: auto;
+  padding: 10px;
+}
+.chat-message {
+  margin-bottom: 8px;
+  background: #fff;
+  padding: 6px 8px;
+  border-radius: 4px;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.1);
+}
+.sets-container {
+  display: flex;
+  gap: 20px;
+}
+.plan-section, .completed-section {
+  flex: 1;
+}
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+table th, table td {
+  border: 1px solid #ddd;
+  padding: 4px;
+}


### PR DESCRIPTION
## Summary
- add global stylesheet for layout and new sidebar
- implement persistent Sidebar with simple chat
- show planned and completed sets side by side
- include styles on app load

## Testing
- `pytest -q` *(fails: connection to 192.168.1.93 refused)*

------
https://chatgpt.com/codex/tasks/task_e_686a3ccf97c48320bcf9fb908eff49e7