### PR TITLE
Use UTC timestamps

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -1,6 +1,6 @@
 import os
 from typing import List
-from datetime import datetime, timedelta
+from datetime import datetime, timezone
 
 from agents import Agent, Runner
 
@@ -11,13 +11,11 @@ import tools
 MODEL = os.environ.get("OPENAI_MODEL", "o4-mini")
 
 def get_corrected_time():
-    """Get current time corrected for server clock being 4 hours fast"""
-    server_time = datetime.now()
-    corrected_time = server_time - timedelta(hours=4)
-    return corrected_time
+    """Get the current UTC time"""
+    return datetime.now(timezone.utc)
 
 def get_timestamp():
-    """Get current timestamp in readable format"""
+    """Get current UTC timestamp in readable format"""
     return get_corrected_time().strftime("[%Y-%m-%d %H:%M:%S]")
 
 def create_agent() -> Agent:

--- a/db.py
+++ b/db.py
@@ -2,7 +2,7 @@ import os
 import psycopg2
 import psycopg2.extras
 import uuid
-from datetime import datetime, date, timedelta
+from datetime import datetime, date, timedelta, timezone
 
 # Database configuration
 DB_HOST = os.environ.get("DB_HOST", "192.168.1.93")
@@ -263,10 +263,9 @@ def populate_comprehensive_sample_data(conn):
     for day_data, log_id in all_completed:
         for exercise, reps, load in day_data:
             exercise_id = exercise_ids[exercise]
-            # Use database default timestamp with timezone correction for sample data
             cur.execute(
-                "INSERT INTO completed_sets (log_id, exercise_id, reps_done, load_done, completed_at) VALUES (%s, %s, %s, %s, CURRENT_TIMESTAMP - INTERVAL '4 hours')",
-                (log_id, exercise_id, reps, load)
+                "INSERT INTO completed_sets (log_id, exercise_id, reps_done, load_done, completed_at) VALUES (%s, %s, %s, %s, %s)",
+                (log_id, exercise_id, reps, load, datetime.now(timezone.utc))
             )
 
 


### PR DESCRIPTION
## Summary
- switch to timezone-aware timestamps in `agent.py`, `tools.py`, and sample data generation
- store `completed_sets` timestamps using UTC

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python test_db_connection.py` *(fails: connection to server at "192.168.1.93" port 5432 failed)*

------
https://chatgpt.com/codex/tasks/task_e_687144855fdc8320a4f6c1ea8ca91e3d