### PR TITLE
Add editable tracked PRs section

### DIFF
--- a/db.py
+++ b/db.py
@@ -34,6 +34,13 @@ DROP TABLE IF EXISTS exercises CASCADE;
 DROP TABLE IF EXISTS timer CASCADE;
 DROP TABLE IF EXISTS chat_messages CASCADE;
 
+CREATE TABLE tracked_prs (
+    exercise VARCHAR(255) NOT NULL,
+    reps INTEGER NOT NULL,
+    max_load REAL NOT NULL,
+    PRIMARY KEY (exercise, reps)
+);
+
 CREATE TABLE exercises (
     id SERIAL PRIMARY KEY,
     name VARCHAR(255) UNIQUE NOT NULL

--- a/server.js
+++ b/server.js
@@ -177,6 +177,39 @@ app.get('/api/prs', async (req, res) => {
   }
 });
 
+// CRUD endpoints for tracked PRs
+app.get('/api/tracked-prs', async (req, res) => {
+  try {
+    const prs = await db.getTrackedPRs();
+    res.json(prs);
+  } catch (error) {
+    console.error('Error getting tracked PRs:', error);
+    res.status(500).json({ error: 'Failed to get tracked PRs' });
+  }
+});
+
+app.put('/api/tracked-prs', async (req, res) => {
+  try {
+    const { exercise, reps, maxLoad } = req.body;
+    await db.upsertTrackedPR(exercise, reps, maxLoad);
+    res.json({ ok: true });
+  } catch (error) {
+    console.error('Error updating tracked PR:', error);
+    res.status(500).json({ error: 'Failed to update tracked PR' });
+  }
+});
+
+app.delete('/api/tracked-prs', async (req, res) => {
+  try {
+    const { exercise, reps } = req.body;
+    await db.deleteTrackedPR(exercise, reps);
+    res.json({ ok: true });
+  } catch (error) {
+    console.error('Error deleting tracked PR:', error);
+    res.status(500).json({ error: 'Failed to delete tracked PR' });
+  }
+});
+
 // Chat endpoint - connects to Python agent
 app.post('/api/chat', async (req, res) => {
   try {

--- a/src/PRTracker.jsx
+++ b/src/PRTracker.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 
 export default function PRTracker({ onBack }) {
   const [prs, setPRs] = useState({});
+  const [tracked, setTracked] = useState({});
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
@@ -21,9 +22,54 @@ export default function PRTracker({ onBack }) {
     }
   };
 
+  const loadTracked = async () => {
+    try {
+      const response = await fetch('/api/tracked-prs');
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      const data = await response.json();
+      setTracked(data);
+    } catch (err) {
+      console.error('Error loading tracked PRs:', err);
+    }
+  };
+
   useEffect(() => {
     loadPRs();
+    loadTracked();
   }, []);
+
+  const saveTracked = async (exercise, reps, maxLoad) => {
+    await fetch('/api/tracked-prs', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ exercise, reps, maxLoad })
+    });
+    loadTracked();
+  };
+
+  const deleteTracked = async (exercise, reps) => {
+    await fetch('/api/tracked-prs', {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ exercise, reps })
+    });
+    loadTracked();
+  };
+
+  const [newExercise, setNewExercise] = useState('');
+  const [newReps, setNewReps] = useState('');
+  const [newLoad, setNewLoad] = useState('');
+
+  const handleAdd = async () => {
+    if (!newExercise || !newReps || !newLoad) return;
+    await saveTracked(newExercise, parseInt(newReps, 10), parseFloat(newLoad));
+    setNewExercise('');
+    setNewReps('');
+    setNewLoad('');
+  };
+
+  const [editing, setEditing] = useState(null); // {exercise, reps}
+  const [editLoad, setEditLoad] = useState('');
 
   // Styles
   const containerStyle = {
@@ -116,6 +162,67 @@ export default function PRTracker({ onBack }) {
     fontSize: '14px'
   };
 
+  const TrackedPRSection = () => {
+    const names = Object.keys(tracked);
+    return (
+      <div>
+        <h2 style={{ marginBottom: '10px' }}>Tracked PRs</h2>
+        {names.length === 0 && (
+          <div style={noDataStyle}>No tracked PRs</div>
+        )}
+        {names.map(ex => (
+          <div key={ex} style={exerciseCardStyle}>
+            <h3 style={exerciseNameStyle}>{ex}</h3>
+            {tracked[ex].map(pr => (
+              editing && editing.exercise === ex && editing.reps === pr.reps ? (
+                <div key={pr.reps} style={{ marginBottom: '8px' }}>
+                  <input
+                    type="number"
+                    value={editLoad}
+                    onChange={e => setEditLoad(e.target.value)}
+                    style={{ marginRight: '8px' }}
+                  />
+                  <button onClick={() => { saveTracked(ex, pr.reps, parseFloat(editLoad)); setEditing(null); }}>Save</button>
+                  <button onClick={() => setEditing(null)}>Cancel</button>
+                </div>
+              ) : (
+                <div key={pr.reps} style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '5px' }}>
+                  <div style={prItemStyle}>{pr.reps} reps: {pr.maxLoad} lbs</div>
+                  <button onClick={() => { setEditing({ exercise: ex, reps: pr.reps }); setEditLoad(pr.maxLoad); }}>Edit</button>
+                  <button onClick={() => deleteTracked(ex, pr.reps)}>Delete</button>
+                </div>
+              )
+            ))}
+          </div>
+        ))}
+        <div style={{ marginTop: '20px' }}>
+          <h3>Add Tracked PR</h3>
+          <input
+            placeholder="Exercise"
+            value={newExercise}
+            onChange={e => setNewExercise(e.target.value)}
+            style={{ marginRight: '8px' }}
+          />
+          <input
+            type="number"
+            placeholder="Reps"
+            value={newReps}
+            onChange={e => setNewReps(e.target.value)}
+            style={{ marginRight: '8px' }}
+          />
+          <input
+            type="number"
+            placeholder="Load"
+            value={newLoad}
+            onChange={e => setNewLoad(e.target.value)}
+            style={{ marginRight: '8px' }}
+          />
+          <button onClick={handleAdd}>Add</button>
+        </div>
+      </div>
+    );
+  };
+
   if (loading) {
     return (
       <div style={containerStyle}>
@@ -179,6 +286,8 @@ export default function PRTracker({ onBack }) {
           ))}
         </div>
       )}
+      <hr style={{ margin: '40px 0' }} />
+      <TrackedPRSection />
     </div>
   );
-} 
+}


### PR DESCRIPTION
## Summary
- add tracked_prs table and related db functions
- expose CRUD endpoints for tracked PRs in server
- enhance PRTracker page with editable tracked PRs list
- update Python schema with tracked_prs table

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871c976e19483208f3f265a309b5fdf