### PR TITLE
Add weekly split planner

### DIFF
--- a/server.js
+++ b/server.js
@@ -55,6 +55,57 @@ app.get('/api/days/:id', async (req, res) => {
   }
 });
 
+// Split (weekly plan) endpoints
+app.get('/api/split', async (req, res) => {
+  try {
+    const split = await db.getAllSplit();
+    res.json(split);
+  } catch (error) {
+    console.error('Error getting split:', error);
+    res.status(500).json({ error: 'Failed to get split' });
+  }
+});
+
+app.get('/api/split/:day', async (req, res) => {
+  try {
+    const items = await db.getSplit(Number(req.params.day));
+    res.json(items);
+  } catch (error) {
+    console.error('Error getting split day:', error);
+    res.status(500).json({ error: 'Failed to get split day' });
+  }
+});
+
+app.post('/api/split/:day', async (req, res) => {
+  try {
+    const id = await db.addSplit(Number(req.params.day), req.body);
+    res.json({ id });
+  } catch (error) {
+    console.error('Error adding split set:', error);
+    res.status(500).json({ error: 'Failed to add split set' });
+  }
+});
+
+app.put('/api/split/plan/:id', async (req, res) => {
+  try {
+    await db.updateSplit(Number(req.params.id), req.body);
+    res.json({ ok: true });
+  } catch (error) {
+    console.error('Error updating split set:', error);
+    res.status(500).json({ error: 'Failed to update split set' });
+  }
+});
+
+app.delete('/api/split/plan/:id', async (req, res) => {
+  try {
+    await db.deleteSplit(Number(req.params.id));
+    res.json({ ok: true });
+  } catch (error) {
+    console.error('Error deleting split set:', error);
+    res.status(500).json({ error: 'Failed to delete split set' });
+  }
+});
+
 app.post('/api/days/:id/plan', async (req, res) => {
   try {
     const id = await db.addPlan(req.params.id, req.body);

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import DayDetail from './DayDetail';
 import ChatBar from './ChatBar';
 import PRTracker from './PRTracker';
+import SplitPlanner from './SplitPlanner';
 
 export default function App() {
   const [days, setDays] = useState([]);
@@ -9,6 +10,7 @@ export default function App() {
   const [loading, setLoading] = useState(true);
   const [lastUpdated, setLastUpdated] = useState(null);
   const [showPRTracker, setShowPRTracker] = useState(false);
+  const [showSplitPlanner, setShowSplitPlanner] = useState(false);
 
   const loadDays = async () => {
     try {
@@ -59,11 +61,19 @@ export default function App() {
   const handleBack = () => {
     setSelected(null);
     setShowPRTracker(false);
+    setShowSplitPlanner(false);
     refreshDays(); // Refresh the list when going back
   };
 
   const handlePRTracker = () => {
     setShowPRTracker(true);
+    setSelected(null);
+    setShowSplitPlanner(false);
+  };
+
+  const handleSplitPlanner = () => {
+    setShowSplitPlanner(true);
+    setShowPRTracker(false);
     setSelected(null);
   };
 
@@ -163,6 +173,18 @@ export default function App() {
     fontWeight: 'bold'
   };
 
+  const splitButtonStyle = {
+    padding: '8px 16px',
+    backgroundColor: '#17a2b8',
+    color: 'white',
+    border: 'none',
+    borderRadius: '4px',
+    cursor: 'pointer',
+    fontSize: '14px',
+    fontWeight: 'bold',
+    marginLeft: '10px'
+  };
+
   return (
     <>
       <div style={containerStyle}>
@@ -177,9 +199,14 @@ export default function App() {
                   </div>
                 )}
               </div>
-              <button style={prButtonStyle} onClick={handlePRTracker}>
-                💪 View PRs
-              </button>
+              <div>
+                <button style={prButtonStyle} onClick={handlePRTracker}>
+                  💪 View PRs
+                </button>
+                <button style={splitButtonStyle} onClick={handleSplitPlanner}>
+                  📅 Edit Split
+                </button>
+              </div>
             </div>
             
             {loading && (
@@ -235,8 +262,11 @@ export default function App() {
             )}
           </div>
         )}
-        {selected && !showPRTracker && <DayDetail id={selected} onBack={handleBack} onDelete={deleteDay} />}
-        {showPRTracker && <PRTracker onBack={handleBack} />}
+        {selected && !showPRTracker && !showSplitPlanner && (
+          <DayDetail id={selected} onBack={handleBack} onDelete={deleteDay} />
+        )}
+        {showPRTracker && !showSplitPlanner && <PRTracker onBack={handleBack} />}
+        {showSplitPlanner && <SplitPlanner onBack={handleBack} />}
       </div>
       <ChatBar />
     </>

--- a/src/SplitPlanner.jsx
+++ b/src/SplitPlanner.jsx
@@ -1,0 +1,147 @@
+import React, { useEffect, useState } from 'react';
+
+export default function SplitPlanner({ onBack }) {
+  const dayNames = ['Sunday','Monday','Tuesday','Wednesday','Thursday','Friday','Saturday'];
+  const emptySet = { exercise: '', reps: 0, load: 0, rest: 60, order_num: 1 };
+  const [split, setSplit] = useState(() => Object.fromEntries(dayNames.map((_,i)=>[i,[]])));
+  const [newSets, setNewSets] = useState(() => Object.fromEntries(dayNames.map((_,i)=>[i,{...emptySet}])));
+  const [loading, setLoading] = useState(true);
+
+  const loadSplit = async () => {
+    try {
+      const resp = await fetch('/api/split');
+      const data = await resp.json();
+      const grouped = Object.fromEntries(dayNames.map((_,i)=>[i,[]]));
+      data.forEach(row => {
+        grouped[row.day_of_week].push(row);
+      });
+      setSplit(grouped);
+      setLoading(false);
+    } catch (err) {
+      console.error('Error loading split:', err);
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => { loadSplit(); }, []);
+
+  const handleChange = async (day, idx, field, value) => {
+    const upd = { ...split[day][idx], [field]: value };
+    const copy = { ...split };
+    copy[day][idx] = upd;
+    setSplit(copy);
+    await fetch(`/api/split/plan/${upd.id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(upd)
+    });
+  };
+
+  const addSet = async (day) => {
+    const payload = newSets[day];
+    await fetch(`/api/split/${day}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    });
+    setNewSets({ ...newSets, [day]: { ...emptySet } });
+    loadSplit();
+  };
+
+  const deleteSet = async (day, id) => {
+    await fetch(`/api/split/plan/${id}`, { method: 'DELETE' });
+    loadSplit();
+  };
+
+  const containerStyle = { padding: '20px', maxWidth: '1000px', margin: '0 auto', fontFamily: 'Arial, sans-serif' };
+  const backButtonStyle = { padding: '8px 16px', backgroundColor: '#007bff', color:'white', border:'none', borderRadius:'4px', cursor:'pointer', marginBottom:'20px' };
+  const tableStyle = { width:'100%', borderCollapse:'collapse', fontSize:'14px' };
+  const thStyle = { backgroundColor:'#f8f9fa', padding:'8px', textAlign:'left', borderBottom:'1px solid #ddd', fontSize:'12px', fontWeight:'bold' };
+  const tdStyle = { padding:'4px', borderBottom:'1px solid #eee' };
+  const inputStyle = { width:'100%', padding:'4px', border:'1px solid #ccc', borderRadius:'3px', fontSize:'14px' };
+  const numberInputStyle = { ...inputStyle, width:'60px', textAlign:'center' };
+  const orderInputStyle = { ...inputStyle, width:'40px', textAlign:'center' };
+  const restInputStyle = { ...inputStyle, width:'50px', textAlign:'center' };
+  const buttonStyle = { padding:'4px 8px', backgroundColor:'#dc3545', color:'white', border:'none', borderRadius:'3px', cursor:'pointer', fontSize:'12px' };
+  const addButtonStyle = { ...buttonStyle, backgroundColor:'#28a745' };
+
+  return (
+    <div style={containerStyle}>
+      <button style={backButtonStyle} onClick={onBack}>← Back</button>
+      <h2>Weekly Split</h2>
+      {loading && <p>Loading split...</p>}
+      {!loading && dayNames.map((name, idx) => (
+        <div key={idx} style={{marginBottom:'40px'}}>
+          <h3 style={{marginBottom:'10px'}}>{name}</h3>
+          <table style={tableStyle}>
+            <thead>
+              <tr>
+                <th style={thStyle}>Exercise</th>
+                <th style={thStyle}>Reps</th>
+                <th style={thStyle}>Load</th>
+                <th style={thStyle}>Rest</th>
+                <th style={thStyle}>Order</th>
+                <th style={thStyle}>Action</th>
+              </tr>
+            </thead>
+            <tbody>
+              {split[idx].map((p, i) => (
+                <tr key={p.id}>
+                  <td style={tdStyle}>
+                    <input style={inputStyle} value={p.exercise}
+                      onChange={e=>handleChange(idx,i,'exercise',e.target.value)} />
+                  </td>
+                  <td style={tdStyle}>
+                    <input style={numberInputStyle} type="number" value={p.reps}
+                      onChange={e=>handleChange(idx,i,'reps',e.target.value)} />
+                  </td>
+                  <td style={tdStyle}>
+                    <input style={numberInputStyle} type="number" value={p.load}
+                      onChange={e=>handleChange(idx,i,'load',e.target.value)} />
+                  </td>
+                  <td style={tdStyle}>
+                    <input style={restInputStyle} type="number" value={p.rest || 60}
+                      onChange={e=>handleChange(idx,i,'rest',e.target.value)} />
+                  </td>
+                  <td style={tdStyle}>
+                    <input style={orderInputStyle} type="number" value={p.order_num}
+                      onChange={e=>handleChange(idx,i,'order_num',e.target.value)} />
+                  </td>
+                  <td style={tdStyle}>
+                    <button style={buttonStyle} onClick={()=>deleteSet(idx,p.id)}>Remove</button>
+                  </td>
+                </tr>
+              ))}
+              <tr style={{backgroundColor:'#f8f9fa'}}>
+                <td style={tdStyle}>
+                  <input style={inputStyle} value={newSets[idx].exercise}
+                    onChange={e=>setNewSets({...newSets,[idx]:{...newSets[idx],exercise:e.target.value}})}
+                    placeholder="Exercise" />
+                </td>
+                <td style={tdStyle}>
+                  <input style={numberInputStyle} type="number" value={newSets[idx].reps}
+                    onChange={e=>setNewSets({...newSets,[idx]:{...newSets[idx],reps:e.target.value}})} />
+                </td>
+                <td style={tdStyle}>
+                  <input style={numberInputStyle} type="number" value={newSets[idx].load}
+                    onChange={e=>setNewSets({...newSets,[idx]:{...newSets[idx],load:e.target.value}})} />
+                </td>
+                <td style={tdStyle}>
+                  <input style={restInputStyle} type="number" value={newSets[idx].rest}
+                    onChange={e=>setNewSets({...newSets,[idx]:{...newSets[idx],rest:e.target.value}})} />
+                </td>
+                <td style={tdStyle}>
+                  <input style={orderInputStyle} type="number" value={newSets[idx].order_num}
+                    onChange={e=>setNewSets({...newSets,[idx]:{...newSets[idx],order_num:e.target.value}})} />
+                </td>
+                <td style={tdStyle}>
+                  <button style={addButtonStyle} onClick={()=>addSet(idx)}>Add</button>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- support weekly split plans in database
- auto-load split when a day has no plan
- expose REST endpoints for split management
- add UI page to edit weekly split
- link split planner from main page

## Testing
- `npm run build` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6871e03f95e0832088d2773fe913b55a